### PR TITLE
added csfr example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,3 @@ XeroNetStandardApp/xerotoken.json
 XeroNetStandardApp/tenantid.json
 XeroNetStandardApp/xerotoken.json
 XeroNetStandardApp/appsettings.json
-XeroNetStandardApp/appsettings.json
-XeroNetStandardApp/appsettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ XeroNetStandardApp/tenantid.json
 XeroNetStandardApp/xerotoken.json
 XeroNetStandardApp/appsettings.json
 XeroNetStandardApp/appsettings.json
+XeroNetStandardApp/appsettings.json

--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ Start your Testing.
 
 Xero token is stored in a JSON file in the root of the project "./xerotoken.json". The app serialise and deserialise with the static class functions in /Utilities/TokenUtilities.cs. Most controllers will get and refresh token before calling API methods.
 
+## Cross Site Forgery Attack Example
+For demonstrating OAuth 2.0 (CSFR)[https://auth0.com/docs/protocols/state-parameters]implementation, two static methods were created to handle local storage of current state (state.json): TokenUtilities.StoreState(string state) and TokenUtilities.GetCurrentState(). 
+
+In AuthenticationController, on construction it generates a random GUID string as state. The Index() will store the state to state.json, then be retrieved on Callback(). If state does not match, the controller returns a warning "Cross site forgery attack detected!" instead of carrying forward the token request flow.
+
 ## License
 
 This software is published under the [MIT License](http://en.wikipedia.org/wiki/MIT_License).

--- a/XeroNetStandardApp/Controllers/AuthorizationController.cs
+++ b/XeroNetStandardApp/Controllers/AuthorizationController.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xero.NetStandard.OAuth2.Models;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace XeroNetStandardApp.Controllers
 {
@@ -16,25 +17,35 @@ namespace XeroNetStandardApp.Controllers
   {
     private readonly ILogger<AuthorizationController> _logger;
     private readonly IOptions<XeroConfiguration> XeroConfig;
-
+    
     // GET /Authorization/
     public AuthorizationController(IOptions<XeroConfiguration> XeroConfig, ILogger<AuthorizationController> logger)
     {
       _logger = logger;
       this.XeroConfig = XeroConfig;
+
     }
 
     public IActionResult Index()
     {
-
       var client = new XeroClient(XeroConfig.Value);
 
-      return Redirect(client.BuildLoginUri());
+      var clientState = Guid.NewGuid().ToString(); 
+      TokenUtilities.StoreState(clientState);
+
+      return Redirect(client.BuildLoginUri(clientState));
     }
 
     // GET /Authorization/Callback
     public async Task<ActionResult> Callback(string code, string state)
     {
+      var clientState = TokenUtilities.GetCurrentState();
+      
+      if (state != clientState) {
+        return Content("Cross site forgery attack detected!");
+      }
+      
+
       var client = new XeroClient(XeroConfig.Value);
       var xeroToken = (XeroOAuth2Token)await client.RequestAccessTokenAsync(code);
 

--- a/XeroNetStandardApp/Controllers/AuthorizationController.cs
+++ b/XeroNetStandardApp/Controllers/AuthorizationController.cs
@@ -23,13 +23,12 @@ namespace XeroNetStandardApp.Controllers
     {
       _logger = logger;
       this.XeroConfig = XeroConfig;
-
     }
 
     public IActionResult Index()
     {
       var client = new XeroClient(XeroConfig.Value);
-
+      
       var clientState = Guid.NewGuid().ToString(); 
       TokenUtilities.StoreState(clientState);
 
@@ -43,8 +42,7 @@ namespace XeroNetStandardApp.Controllers
       
       if (state != clientState) {
         return Content("Cross site forgery attack detected!");
-      }
-      
+      }    
 
       var client = new XeroClient(XeroConfig.Value);
       var xeroToken = (XeroOAuth2Token)await client.RequestAccessTokenAsync(code);

--- a/XeroNetStandardApp/Utilities/TokenUtilities.cs
+++ b/XeroNetStandardApp/Utilities/TokenUtilities.cs
@@ -12,6 +12,14 @@ using Microsoft.Extensions.DependencyInjection;
 
 public static class TokenUtilities
 {
+  [Serializable]
+  public struct State
+  {  
+    public string state {get; set;}
+    public State(string state){
+      this.state = state;
+    }
+  }
   public static void StoreToken(XeroOAuth2Token xeroToken)
   {
     string serializedXeroToken = JsonSerializer.Serialize(xeroToken);
@@ -78,4 +86,28 @@ public static class TokenUtilities
 
     return id;
   }
+
+  public static void StoreState(string state)
+  {
+    State currentState = new State(state);
+    string serializedState = JsonSerializer.Serialize(currentState);
+    System.IO.File.WriteAllText("./state.json", serializedState);
+  }
+
+  public static string GetCurrentState()
+  {
+    string state;
+    try
+    {
+      string serializedIndexFile = System.IO.File.ReadAllText("./state.json");
+      state = JsonSerializer.Deserialize<State>(serializedIndexFile).state;
+    }
+    catch (IOException)
+    {
+      state = null;
+    }
+
+    return state;
+  }
+
 }

--- a/XeroNetStandardApp/Utilities/TokenUtilities.cs
+++ b/XeroNetStandardApp/Utilities/TokenUtilities.cs
@@ -109,5 +109,4 @@ public static class TokenUtilities
 
     return state;
   }
-
 }


### PR DESCRIPTION
To demonstrate CSFR implementation, two methods were added to TokenUtilities: StoreState(string state) and GetCurrentState(). A state.json is used to act as local storage for state. 

On AuthenticationController, on construction it generates a random GUID string as state. The Index() will store this to state.json, then retrieved on Callback(). If state does not match, the controller returns a warning instead of carrying forward the token request.  