### PR TITLE
Upgrade to .NET 6.0

### DIFF
--- a/XeroNetStandardApp/XeroNetStandardApp.csproj
+++ b/XeroNetStandardApp/XeroNetStandardApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- dotnetcore.3.1 is no longer supported (retirement date was Dec 13, 2022)
- .NET 6.0 is LTS and valid until end of 2024


