### PR TITLE
Fix rendering of dates in filesync view

### DIFF
--- a/XeroNetStandardApp/Views/FilesSync/Index.cshtml
+++ b/XeroNetStandardApp/Views/FilesSync/Index.cshtml
@@ -20,8 +20,8 @@
             <td>@item.Name</td>
             <td>@item.MimeType</td>
             <td>@(item.Size / 1024) KB</td>
-            <td>@item.CreatedDateUtc.ToString("d/MM/yy")</td>
-            <td>@item.UpdatedDateUtc.ToString("d/MM/yy")</td>
+            <td>@DateTime.Parse(item.CreatedDateUtc).ToString("dd/MM/yyyy")</td>
+            <td>@DateTime.Parse(item.UpdatedDateUtc).ToString("dd/MM/yyyy")</td>
             <td>@item.Id?.ToString().Substring(0,8)</td>
             <td>@item.FolderId?.ToString().Substring(0,8)</td>
             <td>


### PR DESCRIPTION
The FileSync view throwing an exception because the view was applying a Date style format to a string object. Fix by converting to a DateTime object first, and then apply date style formatting.